### PR TITLE
Fix BipolarSchemeTable

### DIFF
--- a/spec/ndx-bipolar-scheme.extensions.yaml
+++ b/spec/ndx-bipolar-scheme.extensions.yaml
@@ -3,6 +3,11 @@ groups:
   neurodata_type_inc: LabMetaData
   default_name: ecephys_ext
   doc: Group that holds proposed extracellular electrophysiology extensions.
+  groups:
+  - name: bipolar_scheme_table
+    neurodata_type_inc: BipolarSchemeTable
+    doc: Bipolar referencing scheme used
+    quantity: '?'
 - neurodata_type_def: BipolarSchemeTable
   neurodata_type_inc: DynamicTable
   default_name: bipolar_scheme

--- a/spec/ndx-bipolar-scheme.extensions.yaml
+++ b/spec/ndx-bipolar-scheme.extensions.yaml
@@ -24,14 +24,14 @@ groups:
     shape:
     - null
     doc: references the electrodes table
-  - name: anodes_vector_index
+  - name: anodes_index
     neurodata_type_inc: VectorIndex
     dims:
     - num_electrode_grp
     shape:
     - null
     doc: Indices for the anode table
-  - name: cathodes_vector_index
+  - name: cathodes_index
     neurodata_type_inc: VectorIndex
     dims:
     - num_electrode_grp

--- a/src/pynwb/ndx_bipolar_scheme/bipolar_scheme.py
+++ b/src/pynwb/ndx_bipolar_scheme/bipolar_scheme.py
@@ -23,8 +23,10 @@ class BipolarSchemeTable(DynamicTable):
     """
 
     __columns__ = (
-        {'name': 'anodes', 'description': 'references the electrodes table', 'required': True, 'index': True, 'table': True},
-        {'name': 'cathodes', 'description': 'references the electrodes table', 'required': True, 'index': True, 'table': True}
+        {'name': 'anodes', 'description': 'references the electrodes table', 'required': True, 'index': True, 
+         'table': True},
+        {'name': 'cathodes', 'description': 'references the electrodes table', 'required': True, 'index': True,
+         'table': True}
     )
 
     @docval(dict(name='name', type=str, doc='name of this BipolarSchemeTable',

--- a/src/pynwb/ndx_bipolar_scheme/bipolar_scheme.py
+++ b/src/pynwb/ndx_bipolar_scheme/bipolar_scheme.py
@@ -8,12 +8,12 @@ class EcephysExt(LabMetaData):
     """
     Meta data for bipolar scheme
     """
-    __nwbfields__ = ('ecephys_ext',)
+    __nwbfields__ = ('name',
+                     {'name': 'bipolar_scheme_table', 'child': True})
 
-    @docval(dict(name='ecephys_ext', type=str, doc='name of this EcephysExt', default='EcephysExt'),  # required
-            *get_docval(LabMetaData.__init__))
+    @docval(dict(name='name', type=str, doc='name of this EcephysExt', default='EcephysExt'))  # required
     def __init__(self, **kwargs):
-        call_docval_func(super(EcephysExt, self).__init__, kwargs)
+        call_docval_func(super().__init__, kwargs)
 
 
 @register_class('BipolarSchemeTable', 'ndx-bipolar-scheme')

--- a/src/pynwb/ndx_bipolar_scheme/bipolar_scheme.py
+++ b/src/pynwb/ndx_bipolar_scheme/bipolar_scheme.py
@@ -1,7 +1,6 @@
-from pynwb import register_class, register_map
+from pynwb import register_class
 from pynwb.file import LabMetaData, DynamicTable
 from hdmf.utils import docval, call_docval_func, get_docval
-from hdmf.common.io.table import DynamicTableMap
 
 
 @register_class('EcephysExt', 'ndx-bipolar-scheme')
@@ -35,8 +34,3 @@ class BipolarSchemeTable(DynamicTable):
             *get_docval(DynamicTable.__init__, 'id', 'columns', 'colnames'))
     def __init__(self, **kwargs):
         call_docval_func(super(BipolarSchemeTable, self).__init__, kwargs)
-
-
-@register_map(BipolarSchemeTable)
-class BipolarSchemeTableMap(DynamicTableMap):
-    pass

--- a/src/pynwb/tests/test_ext.py
+++ b/src/pynwb/tests/test_ext.py
@@ -45,14 +45,14 @@ def test_ext():
     nwbfile.add_acquisition(ec_series)
 
     ecephys_ext = EcephysExt(name='ecephys_ext')
+    ecephys_ext.bipolar_scheme_table = bipolar_scheme_table
     nwbfile.add_lab_meta_data(ecephys_ext)
-
 
     with NWBHDF5IO('test_nwb.nwb', 'w') as io:
         io.write(nwbfile)
 
     with NWBHDF5IO('test_nwb.nwb', 'r', load_namespaces=True) as io:
         nwbfile = io.read()
-        assert_array_equal(nwbfile.acquisition['test_ec_series'].electrodes.table['anode'][2]['x'], [0., 1.])
+        assert_array_equal(nwbfile.acquisition['test_ec_series'].electrodes.table['anodes'][2]['x'], [0., 1.])
 
     os.remove('test_nwb.nwb')

--- a/src/pynwb/tests/test_ext.py
+++ b/src/pynwb/tests/test_ext.py
@@ -1,6 +1,6 @@
 import os
 from pynwb import NWBHDF5IO, NWBFile
-from pynwb.file import DynamicTable, DynamicTableRegion
+from pynwb.file import DynamicTableRegion
 from datetime import datetime
 from ndx_bipolar_scheme import BipolarSchemeTable, EcephysExt
 from pynwb.ecephys import ElectricalSeries
@@ -21,12 +21,12 @@ def test_ext():
         nwbfile.add_electrode(i, i, i, np.nan, 'loc', 'filt', electrode_group)
 
     bipolar_scheme_table = BipolarSchemeTable(name='bipolar_scheme_table',
-                                          description='desc')
-    
+                                              description='desc')
+
     bipolar_scheme_table.add_row(anodes=[0], cathodes=[1])
     bipolar_scheme_table.add_row(anodes=[0, 1], cathodes=[2, 3])
     bipolar_scheme_table.add_row(anodes=[0, 1], cathodes=[2])
-    
+
     bipolar_scheme_table.anodes.table = nwbfile.electrodes
     bipolar_scheme_table.cathodes.table = nwbfile.electrodes
 

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -73,13 +73,11 @@ def main():
         shape=(None,)
     )
 
-    new_data_types1 = [ecephys_ext]
-    new_data_types2 = [bipolar_scheme]
+    new_data_types = [ecephys_ext, bipolar_scheme]
 
     # export the spec to yaml files in the spec folder
     output_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'spec'))
-    export_spec(ns_builder, new_data_types1, output_dir)
-    export_spec(ns_builder, new_data_types2, output_dir)
+    export_spec(ns_builder, new_data_types, output_dir)
 
 
 if __name__ == "__main__":

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -23,7 +23,13 @@ def main():
         doc='Group that holds proposed extracellular electrophysiology extensions.',
         neurodata_type_def='EcephysExt',
         neurodata_type_inc='LabMetaData',
-        default_name='ecephys_ext'
+        default_name='ecephys_ext',
+        groups=[NWBGroupSpec(
+            name='bipolar_scheme_table',
+            neurodata_type_inc='BipolarSchemeTable',
+            doc='Bipolar referencing scheme used',
+            quantity='?'
+        )]
     )
 
     bipolar_scheme = NWBGroupSpec(

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -52,7 +52,7 @@ def main():
     )
 
     bipolar_scheme.add_dataset(
-        name='anodes_vector_index',
+        name='anodes_index',
         neurodata_type_inc='VectorIndex',
         doc='Indices for the anode table',
         dims=('num_electrode_grp',),
@@ -60,7 +60,7 @@ def main():
     )
 
     bipolar_scheme.add_dataset(
-        name='cathodes_vector_index',
+        name='cathodes_index',
         neurodata_type_inc='VectorIndex',
         doc='Indices for the cathode table',
         dims=('num_electrode_grp',),


### PR DESCRIPTION
1. The column index field should be named `[column_name]_index`, not `[column_name]_vector_index`
2. The test needs to add the table into the file somewhere. I added it as an optional group in `EcephysExt`
3. I think the first docval arg for `EcephysExt` should be 'name'
4. The default `DynamicTableMap` should work fine so I removed `BipolarSchemeTableMap`
5. I did some minor code cleanup

This PR merges into the BipolarSchemeTable branch.